### PR TITLE
Implement Keep Alive packets for TCP

### DIFF
--- a/Hazel.UnitTests/TcpConnectionTests.cs
+++ b/Hazel.UnitTests/TcpConnectionTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Net;
 using System.Threading;

--- a/Hazel/Connection.KeepAlive.cs
+++ b/Hazel/Connection.KeepAlive.cs
@@ -56,7 +56,7 @@ namespace Hazel
         /// </summary>
         bool keepAliveTimerDisposed;
 
-        readonly byte[] helloPacket = new byte[1];
+        readonly byte[] keepAlivePacket = new byte[1];
 
         /// <summary>
         ///     Starts the keepalive timer.
@@ -69,7 +69,7 @@ namespace Hazel
                     (o) =>
                     {
                         Trace.WriteLine("Keepalive packet sent.");
-                        SendBytes(helloPacket, SendOption.Reliable);
+                        SendBytes(keepAlivePacket, SendOption.KeepAlive);
                     },
                     null,
                     keepAliveInterval,

--- a/Hazel/Connection.cs
+++ b/Hazel/Connection.cs
@@ -32,7 +32,7 @@ namespace Hazel
     ///     </para>
     /// </remarks>
     /// <threadsafety static="true" instance="true"/>
-    public abstract class Connection : IDisposable
+    public abstract partial class Connection : IDisposable
     {
         /// <summary>
         ///     Called when a message has been received.
@@ -261,6 +261,7 @@ namespace Hazel
         {
             if (disposing)
             {
+                DisposeKeepAliveTimer();
             }
         }
     }

--- a/Hazel/Hazel.csproj
+++ b/Hazel/Hazel.csproj
@@ -49,6 +49,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Connection.KeepAlive.cs" />
     <Compile Include="Connection.cs" />
     <Compile Include="ConnectionEndPoint.cs" />
     <Compile Include="ConnectionListener.cs" />
@@ -75,7 +76,6 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="Udp\UdpConnection.Fragmented.cs" />
-    <Compile Include="Udp\UdpConnection.KeepAlive.cs" />
     <Compile Include="Udp\UdpConnection.Reliable.cs" />
     <Compile Include="Udp\UdpConnectionListener.cs" />
     <Compile Include="Udp\UdpServerConnection.cs" />

--- a/Hazel/SendOption.cs
+++ b/Hazel/SendOption.cs
@@ -42,6 +42,15 @@ namespace Hazel
         ///     guaranteed to arrive and to arrive only once but the sending process may require more memory, processing,
         ///     a larger number protocol bytes and may be slower than sending unreliably.
         /// </remarks>
-        FragmentedReliable = 2
+        FragmentedReliable = 2,
+
+        /// <summary>
+        ///     Requests data be treated as keep alive packet.
+        /// </summary>
+        /// <remarks>
+        ///     This packet type is used soly to keep connection working.
+        ///     Data inside keep alive packet will be ignored.
+        /// </remarks>
+        KeepAlive = 3
     }
 }

--- a/Hazel/Tcp/TcpConnection.cs
+++ b/Hazel/Tcp/TcpConnection.cs
@@ -42,6 +42,8 @@ namespace Hazel.Tcp
                 this.socket.NoDelay = true;
 
                 State = ConnectionState.Connected;
+
+                InitializeKeepAliveTimer();
             }
         }
 
@@ -69,7 +71,7 @@ namespace Hazel.Tcp
                         throw new HazelException("IPV6 not supported!");
 
                     socket = new Socket(AddressFamily.InterNetworkV6, SocketType.Stream, System.Net.Sockets.ProtocolType.Tcp);
-                    socket.SetSocketOption(SocketOptionLevel.IPv6, (SocketOptionName)27, false);
+                    socket.SetSocketOption(SocketOptionLevel.IPv6, (SocketOptionName)27, false);                    
                 }
 
                 socket.NoDelay = true;
@@ -123,6 +125,8 @@ namespace Hazel.Tcp
                 State = ConnectionState.Connected;
 
                 SendBytes(actualBytes);
+
+                InitializeKeepAliveTimer();
             }
         }
 
@@ -145,6 +149,8 @@ namespace Hazel.Tcp
                 if (State != ConnectionState.Connected)
                     throw new InvalidOperationException("Could not send data as this Connection is not connected. Did you disconnect?");
             
+                ResetKeepAliveTimer();
+
                 try
                 {
                     socket.BeginSend(fullBytes, 0, fullBytes.Length, SocketFlags.None, null, null);
@@ -302,6 +308,8 @@ namespace Hazel.Tcp
                 HandleDisconnect(new HazelException("An exception occured while completing a chunk read operation.", e));
                 return;
             }
+
+            ResetKeepAliveTimer();
 
             StateObject state = (StateObject)result.AsyncState;
 

--- a/Hazel/Tcp/TcpConnection.cs
+++ b/Hazel/Tcp/TcpConnection.cs
@@ -134,14 +134,15 @@ namespace Hazel.Tcp
         /// <remarks>
         ///     <include file="DocInclude/common.xml" path="docs/item[@name='Connection_SendBytes_General']/*" />
         ///     <para>
-        ///         The sendOption parameter is ignored by the TcpConnection as TCP only supports FragmentedReliable 
-        ///         communication, specifying anything else will have no effect.
+        ///         The sendOption parameter can only be set as FragmentedReliable or KeepAlive.
+        ///         TCP only supports FragmentedReliable communication, specifying anything else will have no effect.
+        ///         KeepAlive packets are still send as FragmentedReliable.
         ///     </para>
         /// </remarks>
         public override void SendBytes(byte[] bytes, SendOption sendOption = SendOption.FragmentedReliable)
         {
             //Get bytes for length
-            byte[] fullBytes = AppendLengthHeader(bytes);
+            byte[] fullBytes = AppendLengthHeader(bytes, sendOption);
 
             //Write the bytes to the socket
             lock (socketLock)
@@ -175,6 +176,22 @@ namespace Hazel.Tcp
         {
             //Get length 
             int length = GetLengthFromBytes(bytes);
+
+            //Check if there is no body -> [KeepAlive] packet, if so then log it and wait for next message
+            if (length == 0)
+            {
+                try
+                {
+                    StartWaitingForHeader(callback);
+                }
+                catch (Exception e)
+                {
+                    HandleDisconnect(new HazelException("An exception occured while initiating a header receive operation.", e));
+                }
+
+                Statistics.LogHelloReceive(bytes.Length + 4);
+                return;
+            }
 
             //Begin receiving the body
             try
@@ -370,16 +387,28 @@ namespace Hazel.Tcp
         ///     Appends the length header to the bytes.
         /// </summary>
         /// <param name="bytes">The source bytes.</param>
+        /// <param name="sendOption">Allows for marking packet as KeepAlive. (Zero body length)</param>
         /// <returns>The new bytes.</returns>
-        static byte[] AppendLengthHeader(byte[] bytes)
+        static byte[] AppendLengthHeader(byte[] bytes, SendOption sendOption)
         {
             byte[] fullBytes = new byte[bytes.Length + 4];
 
-            //Append length
-            fullBytes[0] = (byte)(((uint)bytes.Length >> 24) & 0xFF);
-            fullBytes[1] = (byte)(((uint)bytes.Length >> 16) & 0xFF);
-            fullBytes[2] = (byte)(((uint)bytes.Length >> 8) & 0xFF);
-            fullBytes[3] = (byte)(uint)bytes.Length;
+            if (sendOption == SendOption.KeepAlive)
+            {
+                //Append length as 0
+                fullBytes[0] = 0;
+                fullBytes[1] = 0;
+                fullBytes[2] = 0;
+                fullBytes[3] = 0;
+            }
+            else
+            {
+                //Append length
+                fullBytes[0] = (byte) (((uint) bytes.Length >> 24) & 0xFF);
+                fullBytes[1] = (byte) (((uint) bytes.Length >> 16) & 0xFF);
+                fullBytes[2] = (byte) (((uint) bytes.Length >> 8) & 0xFF);
+                fullBytes[3] = (byte) (uint) bytes.Length;                
+            }
 
             //Add rest of bytes
             Buffer.BlockCopy(bytes, 0, fullBytes, 4, bytes.Length);

--- a/Hazel/Udp/UdpClientConnection.cs
+++ b/Hazel/Udp/UdpClientConnection.cs
@@ -160,6 +160,8 @@ namespace Hazel.Udp
                 Dispose();
                 throw new HazelException("Connection attempt timed out.");
             }
+
+            InitializeKeepAliveTimer();
         }
 
         /// <summary>

--- a/Hazel/Udp/UdpConnection.Fragmented.cs
+++ b/Hazel/Udp/UdpConnection.Fragmented.cs
@@ -10,7 +10,7 @@ namespace Hazel.Udp
         /// <summary>
         ///     The amount of data that can be put into a fragment.
         /// </summary>
-        public int FragmentSize { get { return _fragmentSize; } }
+        public int FragmentSize { get { return fragmentSize; } }
         int fragmentSize = 65507 - 1 - 2 - 2 - 2;
 
         /// <summary>

--- a/Hazel/Udp/UdpConnection.cs
+++ b/Hazel/Udp/UdpConnection.cs
@@ -15,14 +15,6 @@ namespace Hazel.Udp
     public abstract partial class UdpConnection : NetworkConnection
     {
         /// <summary>
-        ///     Creates a new UdpConnection and initializes the keep alive timer.
-        /// </summary>
-        protected UdpConnection()
-        {
-            InitializeKeepAliveTimer();
-        }
-
-        /// <summary>
         ///     Writes the given bytes to the connection.
         /// </summary>
         /// <param name="bytes">The bytes to write.</param>
@@ -194,17 +186,6 @@ namespace Hazel.Udp
         protected void SendDisconnect()
         {
             HandleSend(new byte[0], (byte)UdpSendOption.Disconnect);       //TODO Should disconnect wait for an ack?
-        }
-
-        /// <inheritdoc/>
-        protected override void Dispose(bool disposing)
-        {
-            if (disposing)
-            {
-                DisposeKeepAliveTimer();
-            }
-
-            base.Dispose(disposing);
         }
     }
 }

--- a/Hazel/Udp/UdpConnection.cs
+++ b/Hazel/Udp/UdpConnection.cs
@@ -55,6 +55,7 @@ namespace Hazel.Udp
             {
                 //Handle reliable header and hellos
                 case (byte)SendOption.Reliable:
+                case (byte)SendOption.KeepAlive:
                 case (byte)UdpSendOption.Hello:
                     ReliableSend(sendOption, data, ackCallback);
                     break;
@@ -91,7 +92,8 @@ namespace Hazel.Udp
                     AcknowledgementMessageReceive(buffer);
                     break;
 
-                //We need to acknowledge hello messages but dont want to invoke any events!
+                //We need to acknowledge hello/keep alive messages but dont want to invoke any events!
+                case (byte)SendOption.KeepAlive:
                 case (byte)UdpSendOption.Hello:
                     ProcessReliableReceive(buffer, 1);
                     Statistics.LogHelloReceive(buffer.Length);

--- a/Hazel/Udp/UdpServerConnection.cs
+++ b/Hazel/Udp/UdpServerConnection.cs
@@ -42,6 +42,8 @@ namespace Hazel.Udp
             this.IPMode = IPMode;
 
             State = ConnectionState.Connected;
+
+            InitializeKeepAliveTimer();
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
Closes #7 

I've improved a bit tests for keep alive packets. 
Server tests will now correctly fail - previously was hanging forever.

I've changed keep alive packets to be send only after successful connection.
Previously, after 1000ms from creating new Connection object, keep alive will cause exception.

Lastly, keep alive feature was moved into Connection class to reduce duplication :)