### PR TITLE
Added pption to force reliable ordering of TCP messages.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -191,3 +191,6 @@ GeneratedArtifacts/
 _Pvt_Extensions/
 ModelManifest.xml
 *.ide
+
+# Visual Studio directories
+.vs/

--- a/Hazel/Hazel.csproj
+++ b/Hazel/Hazel.csproj
@@ -65,6 +65,7 @@
     <Compile Include="ObjectPool.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SendOption.cs" />
+    <Compile Include="Tcp\TcpOptions.cs" />
     <Compile Include="Udp\SendOptionInternal.cs" />
     <Compile Include="Tcp\StateObject.cs" />
     <Compile Include="ConnectionStatistics.cs" />

--- a/Hazel/Tcp/TcpConnection.cs
+++ b/Hazel/Tcp/TcpConnection.cs
@@ -190,6 +190,12 @@ namespace Hazel.Tcp
             //Begin receiving from the start
             try
             {
+                 //Fire DataReceived event before reading next message.
+                if(TcpOptions.ForceReliableOrdering == true)
+                {
+                    InvokeDataReceived(bytes, SendOption.FragmentedReliable);
+                }
+
                 StartWaitingForHeader(BodyReadCallback);
             }
             catch (Exception e)
@@ -199,8 +205,11 @@ namespace Hazel.Tcp
 
             Statistics.LogFragmentedReceive(bytes.Length, bytes.Length + 4);
 
-            //Fire DataReceived event
-            InvokeDataReceived(bytes, SendOption.FragmentedReliable);
+            //Fire DataReceived event after reading next message for better throughput.
+            if(TcpOptions.ForceReliableOrdering == false)
+            {
+                InvokeDataReceived(bytes, SendOption.FragmentedReliable);
+            }
         }
 
         /// <summary>

--- a/Hazel/Tcp/TcpOptions.cs
+++ b/Hazel/Tcp/TcpOptions.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Hazel.Tcp
+{
+    public static class TcpOptions
+    {
+        /// <summary>
+        /// Force data received even to fire before reading the next message. 
+        /// Setting to false may offer a slight performance advantage at the risk of compromising message ordering. 
+        /// </summary>
+        public static bool ForceReliableOrdering { get; set; } = false;
+    }
+}


### PR DESCRIPTION
Hi Jamie,

As discussed, I've made an option to toggle the forced reliability of TCP message ordering.

I've made changes to two files:
- Added `TcpOptions `with property `ForceReliableOrdering` to enable forced reliable ordering.
- Modified `TcpConnection.BodyReadCallback` to make use of `ForceReliableOrdering`.

I took a quick look, and it seems that the TcpOptions class is a clean way to go as we do not want to have to set forced order reliability twice (on connection and on `args.Connection` in the `NewConnection `callback).

To use this, simply put `TcpOptions.ForceReliableOrdering = true;` anywhere in your code and messages will arrive in the order in which they were sent. By default, this option is set to `false`.

Please note that I had to add `.vs/` to the bottom of the `.gitignore` file as I was getting` sqllite.db locks`... see: [https://stackoverflow.com/a/48220209/596841](https://stackoverflow.com/a/48220209/596841)

Hope this change is acceptable and that it is helpful.

Kind regards,
Rich